### PR TITLE
#2 Fixed required sync time

### DIFF
--- a/lib/vagrant-reflect/configuration/reflect.rb
+++ b/lib/vagrant-reflect/configuration/reflect.rb
@@ -11,15 +11,6 @@ module VagrantReflect
       def finalize!
         @show_sync_time = 0 if @show_sync_time == UNSET_VALUE
       end
-
-      def validate(_)
-        errors = _detected_errors
-        if show_sync_time != true && show_sync_time != false
-          errors << 'show_sync_time must be TRUE or FALSE'
-        end
-
-        { 'reflect' => errors }
-      end
     end
   end
 end


### PR DESCRIPTION
This allows vagrant to boot without defined option 'show sync time' ( #2 ).  
